### PR TITLE
Ensuring initial comfyui_blender log level is correctly set

### DIFF
--- a/comfyui_blender/settings.py
+++ b/comfyui_blender/settings.py
@@ -337,6 +337,9 @@ def register():
     # Register the project settings to the scene
     bpy.types.Scene.comfyui_project_settings = bpy.props.PointerProperty(type=ProjectSettingsPropertyGroup)
 
+    if bpy.context.preferences.addons["comfyui_blender"].preferences.debug_mode:
+        log.setLevel(logging.DEBUG)
+
 def unregister():
     """Unregister classes."""
 


### PR DESCRIPTION
Currently if debug mode is activated in settings logs are not written unless we toggle the option twice